### PR TITLE
convert guid string to uppercase before comparison

### DIFF
--- a/MvsSln/Core/IsolatedEnv.cs
+++ b/MvsSln/Core/IsolatedEnv.cs
@@ -188,7 +188,7 @@ namespace net.r_eg.MvsSln.Core
 
             foreach(var eProject in PrjCollection.LoadedProjects)
             {
-                if(eProject.GetProjectGuid() != pItem.pGuid) {
+                if(eProject.GetProjectGuid().ToUpper() != pItem.pGuid.ToUpper()) {
                     continue;
                 }
 


### PR DESCRIPTION
fixes an issue with VS2019 lower case guids